### PR TITLE
docs(templates): improve godoc coverage

### DIFF
--- a/generator/templates/actions/actions.gotpl
+++ b/generator/templates/actions/actions.gotpl
@@ -1,7 +1,7 @@
 {{- /*gotype:github.com/prisma/photongo/generator.Root*/ -}}
 
 {{ range $model := $.DMMF.Datamodel.Models }}
-	{{ $name := $model.Name.GoCase }}
+	{{ $name := $model.Name.GoLowerCase }}
 	{{ $modelName := (print $model.Name.GoCase "Model") }}
 	{{ $ns := (print $name "Actions") }}
 	{{ $nsFindOne := (print $name "FindOne") }}
@@ -12,7 +12,7 @@
 		client *Client
 	}
 
-	var {{ $model.Name.GoLowerCase }}Outputs = []field{
+	var {{ $name }}Outputs = []field{
 		{{- range $i := $model.Fields }}
 			{{- if $i.Kind.IncludeInStruct }}
 				{name: "{{ $i.Name.CamelCase }}"},

--- a/generator/templates/actions/create.gotpl
+++ b/generator/templates/actions/create.gotpl
@@ -1,7 +1,7 @@
 {{- /*gotype:github.com/prisma/photongo/generator.Root*/ -}}
 
 {{ range $model := $.DMMF.Datamodel.Models }}
-	{{ $name := $model.Name.GoCase }}
+	{{ $name := $model.Name.GoLowerCase }}
 	{{ $modelName := (print $model.Name.GoCase "Model") }}
 	{{ $ns := (print $name "Actions") }}
 	{{ $result := (print $name "Create" "One") }}
@@ -43,10 +43,10 @@
 	func (r {{ $result }}) Exec(ctx context.Context) ({{ $modelName }}, error) {
 		r.query.operation = "mutation"
 		r.query.method = "createOne"
-		r.query.model = "{{ $name }}"
-		r.query.outputs = {{ $model.Name.GoLowerCase }}Outputs
-		var v CreateOne{{ $name }}Response
+		r.query.model = "{{ $model.Name.GoCase }}"
+		r.query.outputs = {{ $name }}Outputs
+		var v createOne{{ $model.Name.GoCase }}Response
 		err := r.query.exec(ctx, &v)
-		return v.Data.CreateOne{{ $name }}, err
+		return v.Data.CreateOne{{ $model.Name.GoCase }}, err
 	}
 {{ end }}

--- a/generator/templates/actions/create.gotpl
+++ b/generator/templates/actions/create.gotpl
@@ -1,53 +1,52 @@
 {{- /*gotype:github.com/prisma/photongo/generator.Root*/ -}}
 
 {{ range $model := $.DMMF.Datamodel.Models }}
-	{{ range $v := $.DMMF.Variations }}
-		{{ $name := $model.Name.GoCase }}
-		{{ $modelName := (print $model.Name.GoCase "Model") }}
-		{{ $ns := (print $name "Actions") }}
-		{{ $result := (print $name "Create" $v.Name) }}
+	{{ $name := $model.Name.GoCase }}
+	{{ $modelName := (print $model.Name.GoCase "Model") }}
+	{{ $ns := (print $name "Actions") }}
+	{{ $result := (print $name "Create" "One") }}
 
-		func (r {{ $ns }}) Create{{ $v.Name }}(
-			{{ range $field := $model.Fields -}}
-				{{- if $field.IsRequired -}}
-					{{ $field.Name.GoLowerCase }} {{ $name }}{{ $field.Name.GoCase }}SetParams,
-				{{- end }}
-			{{- end -}}
-			optional ...{{ $name }}SetParams,
-		) {{ $result }} {
-			var v {{ $result }}
-			v.query.client = r.client
-			var fields []field
+	// Creates a single user.
+	func (r {{ $ns }}) CreateOne(
+		{{ range $field := $model.Fields -}}
+			{{- if $field.IsRequired -}}
+				{{ $field.Name.GoLowerCase }} {{ $name }}{{ $field.Name.GoCase }}SetParams,
+			{{- end }}
+		{{- end -}}
+		optional ...{{ $name }}SetParams,
+	) {{ $result }} {
+		var v {{ $result }}
+		v.query.client = r.client
+		var fields []field
 
-			{{ range $field := $model.Fields }}
-				{{- if $field.IsRequired -}}
-					fields = append(fields, {{ $field.Name.GoLowerCase }}.data)
-				{{- end }}
-			{{ end }}
+		{{ range $field := $model.Fields }}
+			{{- if $field.IsRequired -}}
+				fields = append(fields, {{ $field.Name.GoLowerCase }}.data)
+			{{- end }}
+		{{ end }}
 
-			for _, q := range optional {
-				fields = append(fields, q.data)
-			}
-
-			v.query.inputs = append(v.query.inputs, input{
-				name:   "data",
-				fields: fields,
-			})
-			return v
+		for _, q := range optional {
+			fields = append(fields, q.data)
 		}
 
-		type {{ $result }} struct {
-			query query
-		}
+		v.query.inputs = append(v.query.inputs, input{
+			name:   "data",
+			fields: fields,
+		})
+		return v
+	}
 
-		func (r {{ $result }}) Exec(ctx context.Context) ({{ if $v.List }}[]{{ end }}{{ $modelName }}, error) {
-			r.query.operation = "mutation"
-			r.query.method = "create{{ $v.Name }}"
-			r.query.model = "{{ $name }}"
-			r.query.outputs = {{ $model.Name.GoLowerCase }}Outputs
-			var v Create{{ $v.Name }}{{ $name }}Response
-			err := r.query.exec(ctx, &v)
-			return v.Data.Create{{ $v.Name }}{{ $name }}, err
-		}
-	{{ end }}
+	type {{ $result }} struct {
+		query query
+	}
+
+	func (r {{ $result }}) Exec(ctx context.Context) ({{ $modelName }}, error) {
+		r.query.operation = "mutation"
+		r.query.method = "createOne"
+		r.query.model = "{{ $name }}"
+		r.query.outputs = {{ $model.Name.GoLowerCase }}Outputs
+		var v CreateOne{{ $name }}Response
+		err := r.query.exec(ctx, &v)
+		return v.Data.CreateOne{{ $name }}, err
+	}
 {{ end }}

--- a/generator/templates/actions/find.gotpl
+++ b/generator/templates/actions/find.gotpl
@@ -8,6 +8,7 @@
 		{{ $result := (print $name "Find" $v.Name) }}
 		{{ $params := (print $name "Params") }}
 
+		// Find{{ $v.Name }} returns {{ $v.Name.CamelCase }} user{{ if $v.List }}s{{ end }}.
 		func (r {{ $ns }}) Find{{ $v.Name }}(params ...{{ $params }}) {{ $result }} {
 			var v {{ $result }}
 			v.query.client = r.client
@@ -26,6 +27,7 @@
 			query query
 		}
 
+		// Exec runs the Find{{ $v.Name }} query and returns {{ $v.Name.CamelCase }} user{{ if $v.List }}s{{ end }}.
 		func (r {{ $result }}) Exec(ctx context.Context) ({{ if $v.List }}[]{{ end }}{{ $modelName }}, error) {
 			r.query.operation = "query"
 			r.query.method = "find{{ $v.Name }}"

--- a/generator/templates/actions/find.gotpl
+++ b/generator/templates/actions/find.gotpl
@@ -2,7 +2,7 @@
 
 {{ range $model := $.DMMF.Datamodel.Models }}
 	{{ range $v := $.DMMF.Variations }}
-		{{ $name := $model.Name.GoCase }}
+		{{ $name := $model.Name.GoLowerCase }}
 		{{ $modelName := (print $model.Name.GoCase "Model") }}
 		{{ $ns := (print $name "Actions") }}
 		{{ $result := (print $name "Find" $v.Name) }}
@@ -31,11 +31,11 @@
 		func (r {{ $result }}) Exec(ctx context.Context) ({{ if $v.List }}[]{{ end }}{{ $modelName }}, error) {
 			r.query.operation = "query"
 			r.query.method = "find{{ $v.Name }}"
-			r.query.model = "{{ $name }}"
-			r.query.outputs = {{ $model.Name.GoLowerCase }}Outputs
-			var v Find{{ $v.Name }}{{ $name }}Response
+			r.query.model = "{{ $model.Name.GoCase }}"
+			r.query.outputs = {{ $name }}Outputs
+			var v find{{ $v.Name }}{{ $model.Name.GoCase }}Response
 			err := r.query.exec(ctx, &v)
-			return v.Data.Find{{ $v.Name }}{{ $name }}, err
+			return v.Data.Find{{ $v.Name }}{{ $model.Name.GoCase }}, err
 		}
 	{{ end }}
 {{ end }}

--- a/generator/templates/actions/structs.gotpl
+++ b/generator/templates/actions/structs.gotpl
@@ -4,11 +4,10 @@
 	{{ $m := $model.Name.GoCase }}
 	{{ $ml := $model.Name.GoLowerCase }}
 	{{ range $action := $.DMMF.Actions }}
-		{{ $a := $action.Name.GoCase }}
 		{{ $an := $action.Name.CamelCase }}
-		type {{ $a }}{{ $m }}Response struct {
+		type {{ $action.Name.GoLowerCase }}{{ $m }}Response struct {
 			Data struct{
-				{{- $a }}{{ $m }} {{ if $action.List -}}[]{{- end -}}{{ $m }}Model `json:"{{ $an }}{{ $m }}"`
+				{{- $action.Name.GoCase }}{{ $m }} {{ if $action.List -}}[]{{- end -}}{{ $m }}Model `json:"{{ $an }}{{ $m }}"`
 			} `json:"data"`
 		}
 	{{ end }}

--- a/generator/templates/client.gotpl
+++ b/generator/templates/client.gotpl
@@ -24,6 +24,23 @@ func getPort() (string, error) {
 	return strconv.Itoa(port), nil
 }
 
+// NewClient creates a new Photon Go client.
+// The client is not connected to the Prisma engine yet.
+//
+// Example:
+//
+//   client := photon.NewClient()
+//   err := client.Connect()
+//   if err != nil {
+//     handle(err)
+//   }
+//
+//   defer func() {
+//     err := client.Disconnect()
+//     if err != nil {
+//       panic(fmt.Errorf("could not disconnect %w", err))
+//     }
+//   }()
 func NewClient() Client {
 	var debug = false
 	c := Client{}
@@ -35,6 +52,7 @@ func NewClient() Client {
 	return c
 }
 
+// Client is the instance of the Photon Go client.
 type Client struct {
 	// cmd holds the prisma binary process
 	cmd *exec.Cmd
@@ -49,10 +67,27 @@ type Client struct {
 	log *log.Logger
 
 	{{ range $model := $.DMMF.Datamodel.Models }}
+		// {{ $model.Name.GoCase }} provides access to CRUD methods.
 		{{ $model.Name.GoCase }} {{ $model.Name.GoCase }}Actions
 	{{- end }}
 }
 
+// Connects to the Prisma query engine. Required to call before accessing data.
+// It is recommended to immediately defer calling Disconnect.
+//
+// Example:
+//
+//   err := client.Connect()
+//   if err != nil {
+//     handle(err)
+//   }
+//
+//   defer func() {
+//     err := client.Disconnect()
+//     if err != nil {
+//       panic(fmt.Errorf("could not disconnect %w", err))
+//     }
+//   }()
 func (c *Client) Connect() error {
 	c.log.Printf("connecting...")
 
@@ -123,6 +158,20 @@ func (c *Client) Connect() error {
 	return nil
 }
 
+// Disconnects from the Prisma query engine.
+// This is usually invoked on kill signals in long running applications (like webservers),
+// or when no database access is needed anymore (like after executing a CLI command).
+//
+// Should be usually invoked directly after calling client.Connect(), for example as follows:
+//
+//   // after client.Connect()
+//
+//   defer func() {
+//     err := client.Disconnect()
+//     if err != nil {
+//       panic(fmt.Errorf("could not disconnect %w", err))
+//     }
+//   }()
 func (c *Client) Disconnect() error {
 	c.log.Printf("disconnecting...")
 

--- a/generator/templates/client.gotpl
+++ b/generator/templates/client.gotpl
@@ -68,7 +68,7 @@ type Client struct {
 
 	{{ range $model := $.DMMF.Datamodel.Models }}
 		// {{ $model.Name.GoCase }} provides access to CRUD methods.
-		{{ $model.Name.GoCase }} {{ $model.Name.GoCase }}Actions
+		{{ $model.Name.GoCase }} {{ $model.Name.GoLowerCase }}Actions
 	{{- end }}
 }
 
@@ -100,7 +100,7 @@ func (c *Client) Connect() error {
 	c.gql = gql
 
 	{{- range $model := $.DMMF.Datamodel.Models }}
-		c.{{ $model.Name.GoCase }} = {{ $model.Name.GoCase }}Actions{client: c}
+		c.{{ $model.Name.GoCase }} = {{ $model.Name.GoLowerCase }}Actions{client: c}
 	{{- end }}
 
 	var path string

--- a/generator/templates/query.gotpl
+++ b/generator/templates/query.gotpl
@@ -6,6 +6,7 @@
 	{{ $nsParams := (print $name "Params") }}
 
 	{{/* Namespace declaration */}}
+	// {{ $name }} acts as a namespaces to access query methods for the {{ $name }} model
 	var {{ $name }} = {{ $nsQuery }}{
 		{{- range $field := $model.Fields }}
 			{{/* Filter non-relations only for now */}}
@@ -19,12 +20,19 @@
 		{{- end }}
 	}
 
+	// {{ $nsQuery }} exposes query functions for the {{ $name }} model
 	type {{ $nsQuery }} struct {
 		{{- range $field := $model.Fields }}
 			{{/* Filter non-relations only for now */}}
 			{{- if $field.Kind.IncludeInStruct -}}
+				// {{ $field.Name.GoCase }}
+				//
+				// @{{ if $field.IsRequired }}required{{ else }}optional{{ end }}
+				{{- if $field.IsUnique }}
+					// @unique
+				{{- end }}
 				{{ $field.Name.GoCase }} {{ $nsQuery }}{{ $field.Name.GoCase }}{{ $field.Type }}
-			{{- end -}}
+			{{ end }}
 		{{- end }}
 	}
 

--- a/generator/templates/query.gotpl
+++ b/generator/templates/query.gotpl
@@ -1,13 +1,13 @@
 {{- /*gotype:github.com/prisma/photongo/generator.Root*/ -}}
 
 {{ range $model := $.DMMF.Datamodel.Models }}
-	{{ $name := $model.Name.GoCase }}
+	{{ $name := $model.Name.GoLowerCase }}
 	{{ $nsQuery := (print $name "Query") }}
 	{{ $nsParams := (print $name "Params") }}
 
 	{{/* Namespace declaration */}}
-	// {{ $name }} acts as a namespaces to access query methods for the {{ $name }} model
-	var {{ $name }} = {{ $nsQuery }}{
+	// {{ $model.Name.GoCase }} acts as a namespaces to access query methods for the {{ $model.Name.GoCase }} model
+	var {{ $model.Name.GoCase }} = {{ $nsQuery }}{
 		{{- range $field := $model.Fields }}
 			{{/* Filter non-relations only for now */}}
 			{{- if $field.Kind.IncludeInStruct -}}

--- a/generator/test/basic/basic_test.go
+++ b/generator/test/basic/basic_test.go
@@ -103,35 +103,6 @@ func TestBasic(t *testing.T) {
 			assert.Equal(t, "findOne2", actual.ID)
 		},
 	}, {
-		name: "FindOne equals",
-		// language=GraphQL
-		before: `
-			mutation {
-				a: createOneUser(data: {
-					id: "findOne1",
-					email: "john@findOne.com",
-					username: "john_doe",
-				}) {
-					id
-				}
-				b: createOneUser(data: {
-					id: "findOne2",
-					email: "jane@findOne.com",
-					username: "jane_doe",
-				}) {
-					id
-				}
-			}
-		`,
-		run: func(t *testing.T, client Client, ctx cx) {
-			actual, err := client.User.FindOne(User.Email.Equals("jane@findOne.com")).Exec(ctx)
-			if err != nil {
-				t.Fatalf("fail %s", err)
-			}
-
-			assert.Equal(t, "findOne2", actual.ID)
-		},
-	}, {
 		name: "FindMany equals",
 		// language=GraphQL
 		before: `

--- a/generator/test/basic/basic_test.go
+++ b/generator/test/basic/basic_test.go
@@ -103,6 +103,35 @@ func TestBasic(t *testing.T) {
 			assert.Equal(t, "findOne2", actual.ID)
 		},
 	}, {
+		name: "FindOne equals",
+		// language=GraphQL
+		before: `
+			mutation {
+				a: createOneUser(data: {
+					id: "findOne1",
+					email: "john@findOne.com",
+					username: "john_doe",
+				}) {
+					id
+				}
+				b: createOneUser(data: {
+					id: "findOne2",
+					email: "jane@findOne.com",
+					username: "jane_doe",
+				}) {
+					id
+				}
+			}
+		`,
+		run: func(t *testing.T, client Client, ctx cx) {
+			actual, err := client.User.FindOne(User.Email.Equals("jane@findOne.com")).Exec(ctx)
+			if err != nil {
+				t.Fatalf("fail %s", err)
+			}
+
+			assert.Equal(t, "findOne2", actual.ID)
+		},
+	}, {
 		name: "FindMany equals",
 		// language=GraphQL
 		before: `


### PR DESCRIPTION
Add godoc comments in templates and un-export most internal structs (for now).

This prevents external usage for now; we may undo this change later on,
although we don't know yet exactly what we want to expose because it is
mostly used internally. However, sometimes users may want to access these,
especially libraries building on top of Photon Go