### PR TITLE
fix(engine): fail on binary targets

### DIFF
--- a/binaries/binaries.go
+++ b/binaries/binaries.go
@@ -49,7 +49,7 @@ func GlobalPath() string {
 }
 
 func fetch(toDir string, engine string, binary string) error {
-	logger.L.Printf("checking %s...", engine)
+	logger.Debug.Printf("checking %s...", engine)
 
 	to := path.Join(toDir, fmt.Sprintf("prisma-%s-%s", engine, binary))
 
@@ -61,17 +61,17 @@ func fetch(toDir string, engine string, binary string) error {
 	url := fmt.Sprintf(EngineURL, EngineVersion, binary, urlName)
 
 	if _, err := os.Stat(to); !os.IsNotExist(err) {
-		logger.L.Printf("%s is cached", to)
+		logger.Debug.Printf("%s is cached", to)
 		return nil
 	}
 
-	logger.L.Printf("%s is missing, downloading...", engine)
+	logger.Debug.Printf("%s is missing, downloading...", engine)
 
 	if err := download(url, to); err != nil {
 		return fmt.Errorf("could not download %s to %s: %w", url, to, err)
 	}
 
-	logger.L.Printf("%s done", engine)
+	logger.Debug.Printf("%s done", engine)
 
 	return nil
 }
@@ -119,13 +119,15 @@ func DownloadCLI(toDir string) error {
 	url := fmt.Sprintf(PrismaURL, "prisma-cli", PrismaVersion, platform.Name())
 
 	if _, err := os.Stat(to); os.IsNotExist(err) {
-		logger.L.Printf("prisma cli doesn't exist, fetching...")
+		logger.Debug.Printf("prisma cli doesn't exist, fetching...")
 
 		if err := download(url, to); err != nil {
 			return fmt.Errorf("could not download %s to %s: %w", url, to, err)
 		}
+
+		logger.Debug.Printf("prisma cli fetched successfully.")
 	} else {
-		logger.L.Printf("prisma cli is cached")
+		logger.Debug.Printf("prisma cli is cached")
 	}
 
 	return nil
@@ -138,7 +140,7 @@ func DownloadEngine(name string, toDir string) (file string, err error) {
 
 	binaryName := platform.BinaryNameWithSSL()
 
-	logger.L.Printf("checking %s...", name)
+	logger.Debug.Printf("checking %s...", name)
 
 	to := path.Join(toDir, fmt.Sprintf("prisma-%s-%s", name, binaryName))
 
@@ -150,20 +152,20 @@ func DownloadEngine(name string, toDir string) (file string, err error) {
 	url := fmt.Sprintf(EngineURL, EngineVersion, binaryName, urlName)
 
 	if _, err := os.Stat(to); !os.IsNotExist(err) {
-		logger.L.Printf("%s is cached", to)
+		logger.Debug.Printf("%s is cached", to)
 		return to, nil
 	}
 
-	logger.L.Printf("%s is missing, downloading...", name)
+	logger.Debug.Printf("%s is missing, downloading...", name)
 
 	startDownload := time.Now()
 	if err := download(url, to); err != nil {
 		return "", fmt.Errorf("could not download %s to %s: %w", url, to, err)
 	}
 
-	logger.L.Printf("download() took %s", time.Since(startDownload))
+	logger.Debug.Printf("download() took %s", time.Since(startDownload))
 
-	logger.L.Printf("%s done", name)
+	logger.Debug.Printf("%s done", name)
 
 	return to, nil
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,7 +13,7 @@ import (
 
 // Run the prisma CLI with given arguments
 func Run(arguments []string, output bool) error {
-	logger.L.Printf("running cli with args %+v", arguments)
+	logger.Debug.Printf("running cli with args %+v", arguments)
 	// TODO respect initial PRISMA_<name>_BINARY env
 
 	dir := binaries.GlobalPath()
@@ -24,7 +24,7 @@ func Run(arguments []string, output bool) error {
 
 	prisma := binaries.PrismaCLIName()
 
-	logger.L.Printf("running %s %+v", path.Join(dir, prisma), arguments)
+	logger.Debug.Printf("running %s %+v", path.Join(dir, prisma), arguments)
 
 	cmd := exec.Command(path.Join(dir, prisma), arguments...)
 	binaryName := platform.BinaryNameWithSSL()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,9 +6,10 @@ import (
 	"time"
 )
 
-func NewEngine(schema string) *Engine {
+func NewEngine(schema string, hasBinaryTargets bool) *Engine {
 	e := &Engine{
-		schema: schema,
+		schema:           schema,
+		hasBinaryTargets: hasBinaryTargets,
 	}
 
 	e.http = &http.Client{
@@ -30,4 +31,8 @@ type Engine struct {
 
 	// schema contains the prisma schema
 	schema string
+
+	// hasBinaryTargets can be toggled by generated code from schema.prisma whether binaryTargets
+	// were specified and thus expects binaries in the local path
+	hasBinaryTargets bool
 }

--- a/generator/templates/client.gotpl
+++ b/generator/templates/client.gotpl
@@ -2,6 +2,14 @@
 
 const schema = `{{ .Datamodel }}`
 
+{{ $hasBinaryTargets := false }}
+{{ if gt (len .Generator.BinaryTargets) 0 }}
+	{{ $hasBinaryTargets = true }}
+{{ end }}
+
+// hasBinaryTargets is true when binaryTargets are provided on generation time
+var hasBinaryTargets = {{ $hasBinaryTargets }}
+
 // NewClient creates a new Photon Go client.
 // The client is not connected to the Prisma engine yet.
 //
@@ -22,7 +30,7 @@ const schema = `{{ .Datamodel }}`
 func NewClient() *Client {
 	c := &Client{}
 
-	c.engine = engine.NewEngine(schema)
+	c.engine = engine.NewEngine(schema, hasBinaryTargets)
 
 	{{- range $model := $.DMMF.Datamodel.Models }}
 		c.{{ $model.Name.GoCase }} = {{ $model.Name.GoLowerCase }}Actions{client: c}

--- a/generator/templates/input.gotpl
+++ b/generator/templates/input.gotpl
@@ -198,7 +198,7 @@ func (q query) exec(ctx context.Context, v interface{}) error {
 
 	{{/* TODO use specific log level */}}
 	if logger.Enabled {
-		logger.L.Printf("prisma query: `%s`", s)
+		logger.Debug.Printf("prisma query: `%s`", s)
 	}
 
 	return q.client.engine.Do(ctx, s, &v)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,11 +11,16 @@ import (
 var v = os.Getenv("PHOTON_GO_LOG")
 var Enabled = v != ""
 
-var L *log.Logger
+var Debug *log.Logger
+var Warn *log.Logger
 
 func init() {
-	L = log.New(ioutil.Discard, "", 0)
+	discard := log.New(ioutil.Discard, "", 0)
+
+	Debug = discard
 	if Enabled {
-		L = log.New(os.Stdout, "", log.Flags())
+		Debug = log.New(os.Stdout, "debug", log.Flags())
 	}
+
+	Warn = log.New(os.Stdout, "warn", log.Flags())
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	if len(os.Args) > 1 {
 		args := os.Args[1:]
-		logger.L.Printf("invoking command %+v", args)
+		logger.Debug.Printf("invoking command %+v", args)
 
 		if args[0] == "prefetch" {
 			// just run prisma -v to trigger the download
@@ -36,7 +36,7 @@ func main() {
 
 	// running the prisma generator
 
-	logger.L.Printf("invoking prisma")
+	logger.Debug.Printf("invoking prisma")
 
 	// exit when signal triggers
 	c := make(chan os.Signal)
@@ -52,5 +52,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger.L.Printf("success")
+	logger.Debug.Printf("success")
 }


### PR DESCRIPTION
When binaryTargets are provided, fail if no engine is found.